### PR TITLE
Adds a Docker image for CLI tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM alpine:3
+FROM mcr.microsoft.com/azure-cli:2.0.77
 
-# Arguments
+# --- Arguments ---
 ARG TERRAFORM_VERSION="0.12.17"
 
-# Re-usable environment variables 
+# --- Re-usable environment variables ---
 ENV TMP_DIR="/tmp"
 ENV TERRAFORM_DIR="/opt/terraform"
 
+# --- Install Terraform ---
 WORKDIR ${TMP_DIR}
-
-# Install Terraform
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/0.12.17/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN unzip terraform.zip
 RUN mkdir ${TERRAFORM_DIR}
-RUN cp terraform ${TERRAFORM_DIR}/.
+RUN mv terraform ${TERRAFORM_DIR}/.
+RUN ln -s ${TERRAFORM_DIR}/terraform /usr/local/bin/terraform
+RUN rm -rf ${TMP_DIR}/*
+WORKDIR /
 
 # Ready for run
-WORKDIR /
-CMD sh
+CMD bash


### PR DESCRIPTION
# Description

Alpine Linux image with Azure CLI and Terraform CLI installed. Goal is to help avoid running commands on the infrastructure from different versions of the CLI tools (Terraform in particular makes a stink about this).

# Test Instructions

1. Start Docker on your machine and move into this repo
1. `docker build -t cds-snc/cppd-infrastructure .`
1. `docker run -it --rm cds-snc/cppd-infrastructure`
1. `terraform --version`
1. `az --version`

# Other

Future instructions/enhancements might include how to do a prompt-less login for `az login` (i.e. importing credentials from host or via `docker run` arguments, etc.