### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Indicates who needs to approve what kinds of pull request based on file touched
-# This file is read in last-in precendence order (i.e. settings for bottom-most win)
-
-# Default: engineering needs to review changes to files
-*   @cds-snc/esdc-cppd-devs


### PR DESCRIPTION
# Description

A request came from CDS security to migrate ESDC collaborators from the CDS GitHub teams to GitHub Outside Collaborators to more tightly control permissions in our GitHub org. Unfortunately, this removed our ability to group reviewers by role due to not being able to associate ESDC team members with a GitHub team. The following situation arose:

For example, to force a dev code review in the past we could do this:
```
*   @cds-snc/esdc-cppd-devs
```

But now, since ESDC folks can't be on GitHub teams as outside collaborators, we'd have something like this:

```
*   @cds-snc/esdc-cppd-devs @calvinrodo
```

This forces both a member of the esdc-cppd-devs AND Calvin to have to approve, meaning Calvin has to approve everything even if either Dave or I have. For policy-related changes, for example, we'd need BOTH Jane and Kyle to approve, not just one of them. This creates a ton of unnecessary bottle necking as we aim to make small changes rapidly.

We'll still try to do this process via honor code (after all, we trust our people), but unfortunately there is no enforcement mechanism given the mix of GitHub functionality (i.e. there is no `OR` in GitHub CODEOWNERS) and CDS policy.