### PR TITLE
#patch adding auto-tagging on merge to master

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,17 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.15.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true

--- a/.github/workflows/tf-compliance-check.yml
+++ b/.github/workflows/tf-compliance-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TF_infra-version: "v0.0.0"
+      TF_VAR_infra-version: "v0.0.0"
       ARM_CLIENT_ID: "${{secrets.CLIENT_ID}}"
       ARM_SUBSCRIPTION_ID: "${{secrets.SUBSCRIPTION_ID}}"
       ARM_TENANT_ID: "${{secrets.TENANT_ID}}"

--- a/.github/workflows/tf-compliance-check.yml
+++ b/.github/workflows/tf-compliance-check.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      TF_infra-version: "v0.0.0"
       ARM_CLIENT_ID: "${{secrets.CLIENT_ID}}"
       ARM_SUBSCRIPTION_ID: "${{secrets.SUBSCRIPTION_ID}}"
       ARM_TENANT_ID: "${{secrets.TENANT_ID}}"

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,7 @@ locals {
     Environment    = var.environment
     Project        = "DTS"
     ServiceOwner   = var.service_owner
+    Version        = var.infra-version
   }
 
   nameprefix = "Es${var.environmentprefix}${var.locationprefix}${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,9 @@ variable "name" {
   description = "(Required) Specify the Service Name."
 }
 
+variable "infra-version" {
+  description = "(Required) Version of the infrastructure."
+}
 variable "location" {
   description = "(Required) Specify the location for these resources. Changing this forces a new resource to be created."
   default     = "canadacentral"


### PR DESCRIPTION
# Description

Add version tag to infra
Add a workflow to tag repo on merge to master with semantic version based on commit messages

#Major will bump major version (n+1).0.0
#Minor will bump minor version 0.(n+1).0
#Patch will bump patch version 0.0.(n+1)

Default (no commit message) will update patch version.

The version in the PR for this repo will tag always right now as 0.0.0 but we don't apply so shouldn't matter. 

# To Test
Merge to master see if it works.